### PR TITLE
Implement room prefabs and dungeon spawning

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -18,10 +18,29 @@ namespace Evolution.Core
         [SerializeField] private SessionManager sessionManager;
         [SerializeField] private string difficulty = "Easy";
 
+        [Serializable]
+        private class RoomPrefabEntry
+        {
+            public RoomType Type;
+            public RoomPrefab Prefab;
+        }
+
+        [SerializeField] private List<RoomPrefabEntry> roomPrefabs = new();
+        [SerializeField] private float roomSize = 10f;
+        [SerializeField] private Transform dungeonRoot;
+
+        private readonly List<RoomPrefab> spawnedRooms = new();
+        private readonly Dictionary<RoomType, RoomPrefab> prefabLookup = new();
+
         public event Action<RoomData> OnRoomEntered;
         public event Action<DungeonData> OnDungeonLoaded;
 
         private SessionData currentSession;
+
+        private void Awake()
+        {
+            BuildPrefabLookup();
+        }
 
         public void StartNewGame(int ownerId)
         {
@@ -30,6 +49,7 @@ namespace Evolution.Core
                 Debug.LogError("GameManager missing dependencies");
                 return;
             }
+            BuildPrefabLookup();
             currentSession = new SessionData
             {
                 SessionId = ownerId, // temporary id if no DB yet
@@ -40,6 +60,7 @@ namespace Evolution.Core
                 Dungeon = generator.GenerateDungeon()
             };
             sessionManager.RegisterSession(currentSession);
+            SpawnFloor(currentSession.CurrentFloor - 1);
             OnDungeonLoaded?.Invoke(currentSession.Dungeon);
             EnterRoom(currentSession.CurrentPosition);
         }
@@ -50,6 +71,8 @@ namespace Evolution.Core
             currentSession = sessionManager.LoadSession(sessionId);
             if (currentSession != null)
             {
+                BuildPrefabLookup();
+                SpawnFloor(currentSession.CurrentFloor - 1);
                 OnDungeonLoaded?.Invoke(currentSession.Dungeon);
                 EnterRoom(currentSession.CurrentPosition);
             }
@@ -108,13 +131,74 @@ namespace Evolution.Core
                 case RoomType.StaircaseDown:
                     currentSession.CurrentFloor++;
                     currentSession.CurrentPosition = Vector2Int.zero;
+                    SpawnFloor(currentSession.CurrentFloor - 1);
                     OnDungeonLoaded?.Invoke(currentSession.Dungeon);
                     break;
                 case RoomType.StaircaseUp:
                     currentSession.CurrentFloor = Math.Max(1, currentSession.CurrentFloor - 1);
                     currentSession.CurrentPosition = Vector2Int.zero;
+                    SpawnFloor(currentSession.CurrentFloor - 1);
                     OnDungeonLoaded?.Invoke(currentSession.Dungeon);
                     break;
+            }
+        }
+
+        private void BuildPrefabLookup()
+        {
+            prefabLookup.Clear();
+            foreach (var entry in roomPrefabs)
+            {
+                if (entry.Prefab != null)
+                    prefabLookup[entry.Type] = entry.Prefab;
+            }
+        }
+
+        private void ClearSpawned()
+        {
+            foreach (var r in spawnedRooms)
+                if (r != null)
+                    Destroy(r.gameObject);
+            spawnedRooms.Clear();
+        }
+
+        private void SpawnFloor(int floorIndex)
+        {
+            if (currentSession == null || currentSession.Dungeon == null) return;
+            if (floorIndex < 0 || floorIndex >= currentSession.Dungeon.Floors.Count) return;
+
+            ClearSpawned();
+            var floor = currentSession.Dungeon.Floors[floorIndex];
+            foreach (var room in floor.Rooms)
+            {
+                if (!prefabLookup.TryGetValue(room.Type, out var prefab) || prefab == null)
+                    continue;
+                Vector3 pos = new Vector3(room.Coord.x * roomSize, 0f, room.Coord.y * roomSize);
+                var inst = Instantiate(prefab, pos, Quaternion.identity, dungeonRoot);
+                SetupDoors(inst, room);
+                spawnedRooms.Add(inst);
+            }
+        }
+
+        private void SetupDoors(RoomPrefab roomPrefab, RoomData data)
+        {
+            if (roomPrefab == null || data == null) return;
+
+            if (roomPrefab.NorthDoor != null) roomPrefab.NorthDoor.gameObject.SetActive(false);
+            if (roomPrefab.EastDoor != null) roomPrefab.EastDoor.gameObject.SetActive(false);
+            if (roomPrefab.SouthDoor != null) roomPrefab.SouthDoor.gameObject.SetActive(false);
+            if (roomPrefab.WestDoor != null) roomPrefab.WestDoor.gameObject.SetActive(false);
+
+            foreach (var conn in data.Connections)
+            {
+                Vector2Int dir = conn - data.Coord;
+                if (dir == Vector2Int.up && roomPrefab.NorthDoor != null)
+                    roomPrefab.NorthDoor.gameObject.SetActive(true);
+                else if (dir == Vector2Int.right && roomPrefab.EastDoor != null)
+                    roomPrefab.EastDoor.gameObject.SetActive(true);
+                else if (dir == Vector2Int.down && roomPrefab.SouthDoor != null)
+                    roomPrefab.SouthDoor.gameObject.SetActive(true);
+                else if (dir == Vector2Int.left && roomPrefab.WestDoor != null)
+                    roomPrefab.WestDoor.gameObject.SetActive(true);
             }
         }
     }

--- a/Assets/Scripts/Dungeon/RoomPrefab.cs
+++ b/Assets/Scripts/Dungeon/RoomPrefab.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Evolution.Dungeon
+{
+    /// <summary>
+    /// Component placed on dungeon room prefabs so doors can be
+    /// enabled based on connections during generation.
+    /// </summary>
+    public class RoomPrefab : MonoBehaviour
+    {
+        public Transform NorthDoor;
+        public Transform EastDoor;
+        public Transform SouthDoor;
+        public Transform WestDoor;
+    }
+}


### PR DESCRIPTION
## Summary
- add `RoomPrefab` component with door transforms
- map `RoomType` to prefabs in `GameManager`
- spawn prefab rooms after dungeon generation
- enable door objects for connected rooms

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e9816ec08328838e838cac386bb7