### PR TITLE
Add reusable door prefab

### DIFF
--- a/Assets/Prefabs/Door.prefab
+++ b/Assets/Prefabs/Door.prefab
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Door
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3} # MeshFilter
+  - component: {fileID: 4} # MeshRenderer
+  - component: {fileID: 5} # BoxCollider
+  - component: {fileID: 6} # Door
+--- !u!4 &2
+Transform:
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &3
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &4
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &5
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &6
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 5}

--- a/Assets/Prefabs/Rooms/Boss.prefab
+++ b/Assets/Prefabs/Rooms/Boss.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Exit.prefab
+++ b/Assets/Prefabs/Rooms/Exit.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Locked.prefab
+++ b/Assets/Prefabs/Rooms/Locked.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Monster.prefab
+++ b/Assets/Prefabs/Rooms/Monster.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Safe.prefab
+++ b/Assets/Prefabs/Rooms/Safe.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Shop.prefab
+++ b/Assets/Prefabs/Rooms/Shop.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/StaircaseDown.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseDown.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/StaircaseUp.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseUp.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Prefabs/Rooms/Treasure.prefab
+++ b/Assets/Prefabs/Rooms/Treasure.prefab
@@ -31,38 +31,118 @@ GameObject:
   m_Name: NorthDoor
   m_Component:
   - component: {fileID: 7}
+  - component: {fileID: 14} # MeshFilter
+  - component: {fileID: 15} # MeshRenderer
+  - component: {fileID: 16} # BoxCollider
+  - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &14
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &15
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &16
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &17
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 16}
 --- !u!1 &8
 GameObject:
   m_Name: EastDoor
   m_Component:
   - component: {fileID: 9}
+  - component: {fileID: 18} # MeshFilter
+  - component: {fileID: 19} # MeshRenderer
+  - component: {fileID: 20} # BoxCollider
+  - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
   m_LocalPosition: {x: 5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &18
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &19
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &20
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &21
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 20}
 --- !u!1 &10
 GameObject:
   m_Name: SouthDoor
   m_Component:
   - component: {fileID: 11}
+  - component: {fileID: 22} # MeshFilter
+  - component: {fileID: 23} # MeshRenderer
+  - component: {fileID: 24} # BoxCollider
+  - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: -5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &22
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &23
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &24
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &25
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 24}
 --- !u!1 &12
 GameObject:
   m_Name: WestDoor
   m_Component:
   - component: {fileID: 13}
+  - component: {fileID: 26} # MeshFilter
+  - component: {fileID: 27} # MeshRenderer
+  - component: {fileID: 28} # BoxCollider
+  - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
   m_LocalPosition: {x: -5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!33 &26
+MeshFilter:
+  m_Mesh: {fileID: 4300000, guid: 9fd342e1-292d-4053-a416-adf5458ec407, type: 3}
+--- !u!23 &27
+MeshRenderer:
+  m_Materials: []
+--- !u!65 &28
+BoxCollider:
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 2, z: 0.25}
+--- !u!114 &29
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: b119e26a-88d1-4f8d-a5bd-82811becb70e, type: 3}
+  locked: 0
+  animator: {fileID: 0}
+  doorCollider: {fileID: 28}

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -212,23 +212,33 @@ namespace Evolution.Core
         {
             if (roomPrefab == null || data == null) return;
 
-            if (roomPrefab.NorthDoor != null) roomPrefab.NorthDoor.gameObject.SetActive(false);
-            if (roomPrefab.EastDoor != null) roomPrefab.EastDoor.gameObject.SetActive(false);
-            if (roomPrefab.SouthDoor != null) roomPrefab.SouthDoor.gameObject.SetActive(false);
-            if (roomPrefab.WestDoor != null) roomPrefab.WestDoor.gameObject.SetActive(false);
+            SetDoorActive(roomPrefab.NorthDoor, false);
+            SetDoorActive(roomPrefab.EastDoor, false);
+            SetDoorActive(roomPrefab.SouthDoor, false);
+            SetDoorActive(roomPrefab.WestDoor, false);
 
             foreach (var conn in data.Connections)
             {
                 Vector2Int dir = conn - data.Coord;
-                if (dir == Vector2Int.up && roomPrefab.NorthDoor != null)
-                    roomPrefab.NorthDoor.gameObject.SetActive(true);
-                else if (dir == Vector2Int.right && roomPrefab.EastDoor != null)
-                    roomPrefab.EastDoor.gameObject.SetActive(true);
-                else if (dir == Vector2Int.down && roomPrefab.SouthDoor != null)
-                    roomPrefab.SouthDoor.gameObject.SetActive(true);
-                else if (dir == Vector2Int.left && roomPrefab.WestDoor != null)
-                    roomPrefab.WestDoor.gameObject.SetActive(true);
+                if (dir == Vector2Int.up)
+                    SetDoorActive(roomPrefab.NorthDoor, true);
+                else if (dir == Vector2Int.right)
+                    SetDoorActive(roomPrefab.EastDoor, true);
+                else if (dir == Vector2Int.down)
+                    SetDoorActive(roomPrefab.SouthDoor, true);
+                else if (dir == Vector2Int.left)
+                    SetDoorActive(roomPrefab.WestDoor, true);
             }
+        }
+
+        private void SetDoorActive(Transform holder, bool active)
+        {
+            if (holder == null) return;
+            var door = holder.GetComponentInChildren<Evolution.Dungeon.Door>(true);
+            if (door != null)
+                door.gameObject.SetActive(active);
+            else
+                holder.gameObject.SetActive(active);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `Door.prefab` with mesh, collider and `Door` component
- embed door prefab data into every room prefab so door placeholders are functional
- enable/disable door objects via helper `SetDoorActive`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4a2ca9ec8328beca0a10b51f61d5