### PR TITLE
Add database scriptable objects and editors

### DIFF
--- a/Assets/Scripts/Data/RoomDataDefinitions.cs
+++ b/Assets/Scripts/Data/RoomDataDefinitions.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Evolution.Dungeon;
+using Evolution.Inventory;
+using Evolution.Combat;
+
+namespace Evolution.Data
+{
+    [System.Serializable]
+    public class RoomDefinition
+    {
+        public RoomType Type;
+        public RoomPrefab Prefab;
+        [TextArea]
+        public string Description;
+    }
+
+    [CreateAssetMenu(fileName = "RoomDatabase", menuName = "Evolution/Room Database")]
+    public class RoomDatabase : ScriptableObject
+    {
+        public List<RoomDefinition> Rooms = new();
+    }
+
+    [System.Serializable]
+    public class EnemyStats
+    {
+        public string Name;
+        public int MaxHp = 10;
+        public int Attack = 1;
+        public int Defense = 0;
+        public float Speed = 1f;
+        public List<Ability> Abilities = new();
+    }
+
+    [CreateAssetMenu(fileName = "EnemyDatabase", menuName = "Evolution/Enemy Database")]
+    public class EnemyDatabase : ScriptableObject
+    {
+        public List<EnemyStats> Enemies = new();
+    }
+
+    [System.Serializable]
+    public class ShopInventory
+    {
+        public string ShopName;
+        public List<ItemData> Items = new();
+    }
+
+    [CreateAssetMenu(fileName = "ShopDatabase", menuName = "Evolution/Shop Database")]
+    public class ShopDatabase : ScriptableObject
+    {
+        public List<ShopInventory> Shops = new();
+    }
+
+    [System.Serializable]
+    public class PlayerClass
+    {
+        public string ClassName;
+        public int BaseHp = 10;
+        public int BaseAttack = 1;
+        public int BaseDefense = 0;
+        public float BaseSpeed = 1f;
+        public List<Ability> Abilities = new();
+    }
+
+    [CreateAssetMenu(fileName = "ClassDatabase", menuName = "Evolution/Class Database")]
+    public class ClassDatabase : ScriptableObject
+    {
+        public List<PlayerClass> Classes = new();
+    }
+
+    [CreateAssetMenu(fileName = "ItemDatabase", menuName = "Evolution/Item Database")]
+    public class ItemDatabase : ScriptableObject
+    {
+        public List<ItemData> Items = new();
+    }
+}

--- a/Assets/Scripts/Editor/ClassEditor.cs
+++ b/Assets/Scripts/Editor/ClassEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class ClassEditor : EditorWindow
+    {
+        private ClassDatabase database;
+
+        [MenuItem("Adventure/Class Editor")]
+        public static void Open()
+        {
+            GetWindow<ClassEditor>("Class Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (ClassDatabase)EditorGUILayout.ObjectField("Database", database, typeof(ClassDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Classes"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<ClassDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/ClassDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/EnemyEditor.cs
+++ b/Assets/Scripts/Editor/EnemyEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class EnemyEditor : EditorWindow
+    {
+        private EnemyDatabase database;
+
+        [MenuItem("Adventure/Enemy Editor")]
+        public static void Open()
+        {
+            GetWindow<EnemyEditor>("Enemy Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (EnemyDatabase)EditorGUILayout.ObjectField("Database", database, typeof(EnemyDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Enemies"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<EnemyDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/EnemyDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/ItemEditor.cs
+++ b/Assets/Scripts/Editor/ItemEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class ItemEditor : EditorWindow
+    {
+        private ItemDatabase database;
+
+        [MenuItem("Adventure/Item Editor")]
+        public static void Open()
+        {
+            GetWindow<ItemEditor>("Item Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (ItemDatabase)EditorGUILayout.ObjectField("Database", database, typeof(ItemDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Items"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<ItemDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/ItemDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/RoomTypeEditor.cs
+++ b/Assets/Scripts/Editor/RoomTypeEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class RoomTypeEditor : EditorWindow
+    {
+        private RoomDatabase database;
+
+        [MenuItem("Adventure/Room Editor")]
+        public static void Open()
+        {
+            GetWindow<RoomTypeEditor>("Room Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (RoomDatabase)EditorGUILayout.ObjectField("Database", database, typeof(RoomDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Rooms"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<RoomDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/RoomDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/ShopEditor.cs
+++ b/Assets/Scripts/Editor/ShopEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class ShopEditor : EditorWindow
+    {
+        private ShopDatabase database;
+
+        [MenuItem("Adventure/Shop Editor")]
+        public static void Open()
+        {
+            GetWindow<ShopEditor>("Shop Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (ShopDatabase)EditorGUILayout.ObjectField("Database", database, typeof(ShopDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Shops"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<ShopDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/ShopDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add scriptable objects for room, enemy, item, shop, and class data
- implement editor windows for managing the new databases

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4f5655a4832891c02f2d558a62b8