### PR TITLE
Add DataManager for central data loading

### DIFF
--- a/Assets/Scripts/Core/DataManager.cs
+++ b/Assets/Scripts/Core/DataManager.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Core
+{
+    /// <summary>
+    /// Loads core game databases from the Resources folder and exposes
+    /// them for other systems to query.
+    /// </summary>
+    public class DataManager : MonoBehaviour
+    {
+        [SerializeField] private RoomDatabase roomDatabase;
+        [SerializeField] private EnemyDatabase enemyDatabase;
+        [SerializeField] private ShopDatabase shopDatabase;
+        [SerializeField] private ClassDatabase classDatabase;
+        [SerializeField] private ItemDatabase itemDatabase;
+
+        private const string DataPath = "Data/";
+
+        private void Awake()
+        {
+            if (roomDatabase == null)
+                roomDatabase = Resources.Load<RoomDatabase>(DataPath + "RoomDatabase");
+            if (enemyDatabase == null)
+                enemyDatabase = Resources.Load<EnemyDatabase>(DataPath + "EnemyDatabase");
+            if (shopDatabase == null)
+                shopDatabase = Resources.Load<ShopDatabase>(DataPath + "ShopDatabase");
+            if (classDatabase == null)
+                classDatabase = Resources.Load<ClassDatabase>(DataPath + "ClassDatabase");
+            if (itemDatabase == null)
+                itemDatabase = Resources.Load<ItemDatabase>(DataPath + "ItemDatabase");
+        }
+
+        public RoomDatabase GetRoomDatabase() => roomDatabase;
+        public EnemyDatabase GetEnemyDatabase() => enemyDatabase;
+        public ShopDatabase GetShopDatabase() => shopDatabase;
+        public ClassDatabase GetClassDatabase() => classDatabase;
+        public ItemDatabase GetItemDatabase() => itemDatabase;
+    }
+}


### PR DESCRIPTION
## Summary
- add `DataManager` class to load ScriptableObject databases
- create `Resources/Data` folder for database assets

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f59154aa0832892a749c8c1694d53