### PR TITLE
Align dungeon prefabs and compute spacing from prefab size

### DIFF
--- a/Assets/Prefabs/Rooms/Boss.prefab
+++ b/Assets/Prefabs/Rooms/Boss.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Exit.prefab
+++ b/Assets/Prefabs/Rooms/Exit.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Locked.prefab
+++ b/Assets/Prefabs/Rooms/Locked.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Monster.prefab
+++ b/Assets/Prefabs/Rooms/Monster.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Safe.prefab
+++ b/Assets/Prefabs/Rooms/Safe.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Shop.prefab
+++ b/Assets/Prefabs/Rooms/Shop.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/StaircaseDown.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseDown.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/StaircaseUp.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseUp.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Prefabs/Rooms/Treasure.prefab
+++ b/Assets/Prefabs/Rooms/Treasure.prefab
@@ -38,7 +38,7 @@ GameObject:
   - component: {fileID: 17} # Door
 --- !u!4 &7
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &14
@@ -68,7 +68,7 @@ GameObject:
   - component: {fileID: 21} # Door
 --- !u!4 &9
 Transform:
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &18
@@ -98,7 +98,7 @@ GameObject:
   - component: {fileID: 25} # Door
 --- !u!4 &11
 Transform:
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: -5.5}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &22
@@ -128,7 +128,7 @@ GameObject:
   - component: {fileID: 29} # Door
 --- !u!4 &13
 Transform:
-  m_LocalPosition: {x: -5, y: 0, z: 0}
+  m_LocalPosition: {x: -5.5, y: 0, z: 0}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
 --- !u!33 &26

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -28,7 +28,6 @@ namespace Evolution.Core
         }
 
         [SerializeField] private List<RoomPrefabEntry> roomPrefabs = new();
-        [SerializeField] private float roomSize = 10f;
         [SerializeField] private Transform dungeonRoot;
 
         private readonly List<RoomPrefab> spawnedRooms = new();
@@ -211,7 +210,8 @@ namespace Evolution.Core
             {
                 if (!prefabLookup.TryGetValue(room.Type, out var prefab) || prefab == null)
                     continue;
-                Vector3 pos = new Vector3(room.Coord.x * roomSize, 0f, room.Coord.y * roomSize);
+                float spacing = prefab.RoomDimensions.x;
+                Vector3 pos = new Vector3(room.Coord.x * spacing, 0f, room.Coord.y * spacing);
                 var inst = Instantiate(prefab, pos, Quaternion.identity, dungeonRoot);
                 SetupDoors(inst, room);
                 spawnedRooms.Add(inst);

--- a/Assets/Scripts/Dungeon/RoomBuilder.cs
+++ b/Assets/Scripts/Dungeon/RoomBuilder.cs
@@ -11,6 +11,21 @@ namespace Evolution.Dungeon
         [SerializeField] private float tileSize = 1f;
         [SerializeField] private string tileSetPath = "Models/Tiles/Base";
 
+        /// <summary>
+        /// Size of the room grid in tiles.
+        /// </summary>
+        public Vector2Int RoomSize => roomSize;
+
+        /// <summary>
+        /// Size of a single tile in world units.
+        /// </summary>
+        public float TileSize => tileSize;
+
+        /// <summary>
+        /// Total room dimensions in world units.
+        /// </summary>
+        public Vector2 RoomDimensions => new Vector2(roomSize.x * tileSize, roomSize.y * tileSize);
+
         private GameObject floorPrefab;
         private GameObject wallPrefab;
         private GameObject doorPrefab;

--- a/Assets/Scripts/Dungeon/RoomPrefab.cs
+++ b/Assets/Scripts/Dungeon/RoomPrefab.cs
@@ -15,6 +15,8 @@ namespace Evolution.Dungeon
         public Door SouthDoor;
         public Door WestDoor;
 
+        private RoomBuilder builder;
+
         private readonly Dictionary<Vector2Int, Door> doorMap = new();
 
         /// <summary>
@@ -25,6 +27,7 @@ namespace Evolution.Dungeon
         private void Awake()
         {
             BuildDoorMap();
+            builder = GetComponent<RoomBuilder>();
         }
 
         /// <summary>
@@ -47,6 +50,19 @@ namespace Evolution.Dungeon
         {
             if (doorMap.Count == 0) BuildDoorMap();
             return doorMap.TryGetValue(direction, out door);
+        }
+
+        /// <summary>
+        /// World dimensions of this room prefab, derived from its RoomBuilder.
+        /// </summary>
+        public Vector2 RoomDimensions
+        {
+            get
+            {
+                if (builder == null)
+                    builder = GetComponent<RoomBuilder>();
+                return builder != null ? builder.RoomDimensions : Vector2.one * 10f;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose room dimensions from `RoomBuilder` and `RoomPrefab`
- use prefab dimensions instead of the old `roomSize` field when spawning rooms
- reposition doors in all room prefabs to match generated wall positions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602556802483289923707dc931fb34