### PR TITLE
Use full namespace for Inventory

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using Evolution.Dungeon;
 using Evolution.Combat;
-using Evolution.Inventory;
 using System.Linq;
 
 namespace Evolution.Core
@@ -38,7 +37,7 @@ namespace Evolution.Core
         public event Action<DungeonData> OnDungeonLoaded;
 
         private SessionData currentSession;
-        private readonly Inventory inventory = new();
+        private readonly Evolution.Inventory.Inventory inventory = new();
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- remove unused `using Evolution.Inventory` directive
- use fully qualified `Evolution.Inventory.Inventory` in `GameManager`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6860313e00b08328aa0794101c36bc60