### PR TITLE
Add Stats database system

### DIFF
--- a/Assets/Scripts/Core/DataManager.cs
+++ b/Assets/Scripts/Core/DataManager.cs
@@ -14,6 +14,7 @@ namespace Evolution.Core
         [SerializeField] private ShopDatabase shopDatabase;
         [SerializeField] private ClassDatabase classDatabase;
         [SerializeField] private ItemDatabase itemDatabase;
+        [SerializeField] private StatsDatabase statsDatabase;
 
         private const string DataPath = "Data/";
 
@@ -29,6 +30,8 @@ namespace Evolution.Core
                 classDatabase = Resources.Load<ClassDatabase>(DataPath + "ClassDatabase");
             if (itemDatabase == null)
                 itemDatabase = Resources.Load<ItemDatabase>(DataPath + "ItemDatabase");
+            if (statsDatabase == null)
+                statsDatabase = Resources.Load<StatsDatabase>(DataPath + "StatsDatabase");
         }
 
         public RoomDatabase GetRoomDatabase() => roomDatabase;
@@ -36,5 +39,6 @@ namespace Evolution.Core
         public ShopDatabase GetShopDatabase() => shopDatabase;
         public ClassDatabase GetClassDatabase() => classDatabase;
         public ItemDatabase GetItemDatabase() => itemDatabase;
+        public StatsDatabase GetStatsDatabase() => statsDatabase;
     }
 }

--- a/Assets/Scripts/Data/RoomDataDefinitions.cs
+++ b/Assets/Scripts/Data/RoomDataDefinitions.cs
@@ -52,13 +52,17 @@ namespace Evolution.Data
     }
 
     [System.Serializable]
+    public class ClassStat
+    {
+        public StatDefinition Stat;
+        public float Value;
+    }
+
+    [System.Serializable]
     public class PlayerClass
     {
         public string ClassName;
-        public int BaseHp = 10;
-        public int BaseAttack = 1;
-        public int BaseDefense = 0;
-        public float BaseSpeed = 1f;
+        public List<ClassStat> Stats = new();
         public List<Ability> Abilities = new();
     }
 

--- a/Assets/Scripts/Data/StatsDatabase.cs
+++ b/Assets/Scripts/Data/StatsDatabase.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Evolution.Data
+{
+    [System.Serializable]
+    public class StatDefinition
+    {
+        public string Name;
+        [TextArea]
+        public string Description;
+        public float DefaultValue;
+    }
+
+    [CreateAssetMenu(fileName = "StatsDatabase", menuName = "Evolution/Stats Database")]
+    public class StatsDatabase : ScriptableObject
+    {
+        public List<StatDefinition> Stats = new();
+    }
+}

--- a/Assets/Scripts/Data/StatsDatabase.cs.meta
+++ b/Assets/Scripts/Data/StatsDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0940bbd82aef6438ab9dd0faf12ba0f0

--- a/Assets/Scripts/Editor/StatsEditor.cs
+++ b/Assets/Scripts/Editor/StatsEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class StatsEditor : EditorWindow
+    {
+        private StatsDatabase database;
+
+        [MenuItem("Adventure/Stats Editor")]
+        public static void Open()
+        {
+            GetWindow<StatsEditor>("Stats Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (StatsDatabase)EditorGUILayout.ObjectField("Database", database, typeof(StatsDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Stats"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<StatsDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/StatsDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/StatsEditor.cs.meta
+++ b/Assets/Scripts/Editor/StatsEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16e20e529e47c4bdab89c7c6de4034bf


### PR DESCRIPTION
## Summary
- add ScriptableObject `StatsDatabase` with list of stat definitions
- add editor window `StatsEditor` to create/edit stats
- load `StatsDatabase` in `DataManager`
- update `PlayerClass` to store arbitrary stats

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686058da99d08328a71b7cd78780791b