### PR TITLE
Introduce ability assets

### DIFF
--- a/Assets/Scripts/Combat/Ability.cs
+++ b/Assets/Scripts/Combat/Ability.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Evolution.Combat
+{
+    [CreateAssetMenu(fileName = "NewAbility", menuName = "Evolution/Ability")]
+    public class Ability : ScriptableObject
+    {
+        public string Name;
+        public int Damage;
+        public int Heal;
+        public StatusEffect Effect;
+        public float Cooldown;
+        public bool TargetSelf;
+    }
+}

--- a/Assets/Scripts/Combat/Ability.cs.meta
+++ b/Assets/Scripts/Combat/Ability.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36425c6ae9f66cadc3016aa9367801cd

--- a/Assets/Scripts/Combat/BattleManager.cs
+++ b/Assets/Scripts/Combat/BattleManager.cs
@@ -6,27 +6,6 @@ using UnityEngine;
 
 namespace Evolution.Combat
 {
-    [Serializable]
-    public class StatusEffect
-    {
-        public string EffectName;
-        public int Remaining;
-        public int DamagePerTurn;
-        public int HealPerTurn;
-        public float SpeedUp;
-        public float SpeedDown;
-    }
-
-    [Serializable]
-    public class Ability
-    {
-        public string Name;
-        public int Damage;
-        public int Heal;
-        public StatusEffect Effect;
-        public float Cooldown;
-        public bool TargetSelf;
-    }
 
     [Serializable]
     public class Combatant
@@ -217,7 +196,11 @@ namespace Evolution.Combat
             if (enemy.Abilities.Count == 0)
             {
                 // ensure at least one basic attack
-                enemy.Abilities.Add(new Ability { Name = "Attack", Damage = 1, Cooldown = 0f });
+                var basic = ScriptableObject.CreateInstance<Ability>();
+                basic.Name = "Attack";
+                basic.Damage = 1;
+                basic.Cooldown = 0f;
+                enemy.Abilities.Add(basic);
             }
 
             foreach (var ability in enemy.Abilities)

--- a/Assets/Scripts/Combat/StatusEffect.cs
+++ b/Assets/Scripts/Combat/StatusEffect.cs
@@ -1,0 +1,16 @@
+using System;
+using UnityEngine;
+
+namespace Evolution.Combat
+{
+    [Serializable]
+    public class StatusEffect
+    {
+        public string EffectName;
+        public int Remaining;
+        public int DamagePerTurn;
+        public int HealPerTurn;
+        public float SpeedUp;
+        public float SpeedDown;
+    }
+}

--- a/Assets/Scripts/Combat/StatusEffect.cs.meta
+++ b/Assets/Scripts/Combat/StatusEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 47a8c259e42808295c088b5c217d9b6c

--- a/Assets/Scripts/Data/AbilityDatabase.cs
+++ b/Assets/Scripts/Data/AbilityDatabase.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Evolution.Combat;
+
+namespace Evolution.Data
+{
+    [CreateAssetMenu(fileName = "AbilityDatabase", menuName = "Evolution/Ability Database")]
+    public class AbilityDatabase : ScriptableObject
+    {
+        public List<Ability> Abilities = new();
+    }
+}

--- a/Assets/Scripts/Data/AbilityDatabase.cs.meta
+++ b/Assets/Scripts/Data/AbilityDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9d19c1d982e111ee5d332c2b3dec243b

--- a/Assets/Scripts/Editor/AbilityEditor.cs
+++ b/Assets/Scripts/Editor/AbilityEditor.cs
@@ -1,0 +1,49 @@
+using UnityEditor;
+using UnityEngine;
+using Evolution.Data;
+
+namespace Evolution.Editor
+{
+    public class AbilityEditor : EditorWindow
+    {
+        private AbilityDatabase database;
+
+        [MenuItem("Adventure/Ability Editor")]
+        public static void Open()
+        {
+            GetWindow<AbilityEditor>("Ability Editor");
+        }
+
+        private void OnGUI()
+        {
+            database = (AbilityDatabase)EditorGUILayout.ObjectField("Database", database, typeof(AbilityDatabase), false);
+
+            if (database == null)
+            {
+                if (GUILayout.Button("Create Database"))
+                    CreateDatabase();
+                return;
+            }
+
+            var so = new SerializedObject(database);
+            so.Update();
+            EditorGUILayout.PropertyField(so.FindProperty("Abilities"), true);
+            so.ApplyModifiedProperties();
+        }
+
+        private void CreateDatabase()
+        {
+            database = ScriptableObject.CreateInstance<AbilityDatabase>();
+            EnsureDataFolder();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/AbilityDatabase.asset");
+            AssetDatabase.CreateAsset(database, path);
+            AssetDatabase.SaveAssets();
+        }
+
+        private void EnsureDataFolder()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/Data"))
+                AssetDatabase.CreateFolder("Assets", "Data");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/AbilityEditor.cs.meta
+++ b/Assets/Scripts/Editor/AbilityEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc9ac92da16cbb0dcb3df86836202245


### PR DESCRIPTION
## Summary
- extract `StatusEffect` and `Ability` into their own combat scripts
- implement `Ability` as a `ScriptableObject`
- add `AbilityDatabase` asset and `AbilityEditor` window for designers
- update `BattleManager` to use ability assets

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605c62e0408328acbb0a23a5a3bb71