### PR TITLE
Add skills UI and player ability selection

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Assets/Scripts/Combat/BattleManager.cs" />
     <Compile Include="Assets/Scripts/Dungeon/RoomBuilder.cs" />
     <Compile Include="Assets/Scripts/UI/UIManager.cs" />
+    <Compile Include="Assets/Scripts/UI/SkillsUI.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets/TextMesh Pro/Shaders/TMPro.cginc" />

--- a/Assets/Scripts/UI/SkillsUI.cs
+++ b/Assets/Scripts/UI/SkillsUI.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Evolution.Combat;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Displays skill buttons for the active player and notifies the BattleManager
+    /// when a skill is chosen.
+    /// </summary>
+    public class SkillsUI : MonoBehaviour
+    {
+        [SerializeField] private BattleManager battleManager;
+        [SerializeField] private Button skillButtonPrefab;
+        [SerializeField] private Transform buttonRoot;
+
+        private readonly List<Button> spawned = new();
+
+        private void OnEnable()
+        {
+            if (battleManager != null)
+            {
+                battleManager.OnSkillsRequested += ShowSkills;
+                battleManager.OnSkillsClosed += HideSkills;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (battleManager != null)
+            {
+                battleManager.OnSkillsRequested -= ShowSkills;
+                battleManager.OnSkillsClosed -= HideSkills;
+            }
+        }
+
+        public void SetBattleManager(BattleManager manager)
+        {
+            if (battleManager != null)
+            {
+                battleManager.OnSkillsRequested -= ShowSkills;
+                battleManager.OnSkillsClosed -= HideSkills;
+            }
+            battleManager = manager;
+            if (battleManager != null)
+            {
+                battleManager.OnSkillsRequested += ShowSkills;
+                battleManager.OnSkillsClosed += HideSkills;
+            }
+        }
+
+        private void ShowSkills(int playerId, List<Ability> abilities)
+        {
+            Clear();
+            if (skillButtonPrefab == null || buttonRoot == null || abilities == null)
+                return;
+
+            foreach (var ab in abilities)
+            {
+                var btn = Instantiate(skillButtonPrefab, buttonRoot);
+                var text = btn.GetComponentInChildren<Text>();
+                if (text != null)
+                    text.text = ab.Name;
+                btn.onClick.AddListener(() => SelectAbility(ab));
+                spawned.Add(btn);
+            }
+        }
+
+        private void HideSkills()
+        {
+            Clear();
+        }
+
+        private void Clear()
+        {
+            foreach (var b in spawned)
+                if (b != null)
+                    Destroy(b.gameObject);
+            spawned.Clear();
+        }
+
+        private void SelectAbility(Ability ability)
+        {
+            if (battleManager != null)
+                battleManager.ChooseAbility(ability);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `BattleManager` so `PlayerTurn` waits for the player's ability choice
- publish callbacks for skill selection UI
- implement a simple `SkillsUI` for showing available abilities
- register new script with the project file

## Testing
- `dotnet build 'AdventureGame 1.0.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605d7051b08328ab00eb6596d3e41d