### PR TITLE
Convert stats to ScriptableObjects

### DIFF
--- a/Assets/Scripts/Data/StatDefinition.cs
+++ b/Assets/Scripts/Data/StatDefinition.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace Evolution.Data
+{
+    [CreateAssetMenu(fileName = "StatDefinition", menuName = "Evolution/Stat Definition")]
+    public class StatDefinition : ScriptableObject
+    {
+        public string Name;
+        [TextArea]
+        public string Description;
+        public float DefaultValue;
+    }
+}

--- a/Assets/Scripts/Data/StatsDatabase.cs
+++ b/Assets/Scripts/Data/StatsDatabase.cs
@@ -3,15 +3,6 @@ using UnityEngine;
 
 namespace Evolution.Data
 {
-    [System.Serializable]
-    public class StatDefinition
-    {
-        public string Name;
-        [TextArea]
-        public string Description;
-        public float DefaultValue;
-    }
-
     [CreateAssetMenu(fileName = "StatsDatabase", menuName = "Evolution/Stats Database")]
     public class StatsDatabase : ScriptableObject
     {

--- a/Assets/Scripts/Editor/ClassEditor.cs
+++ b/Assets/Scripts/Editor/ClassEditor.cs
@@ -7,6 +7,8 @@ namespace Evolution.Editor
     public class ClassEditor : EditorWindow
     {
         private ClassDatabase database;
+        private StatsDatabase statsDatabase;
+        private Vector2 scroll;
 
         [MenuItem("Adventure/Class Editor")]
         public static void Open()
@@ -17,6 +19,7 @@ namespace Evolution.Editor
         private void OnGUI()
         {
             database = (ClassDatabase)EditorGUILayout.ObjectField("Database", database, typeof(ClassDatabase), false);
+            statsDatabase = (StatsDatabase)EditorGUILayout.ObjectField("Stats Database", statsDatabase, typeof(StatsDatabase), false);
 
             if (database == null)
             {
@@ -25,10 +28,63 @@ namespace Evolution.Editor
                 return;
             }
 
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+
             var so = new SerializedObject(database);
             so.Update();
-            EditorGUILayout.PropertyField(so.FindProperty("Classes"), true);
+            SerializedProperty classesProp = so.FindProperty("Classes");
+
+            for (int i = 0; i < classesProp.arraySize; i++)
+            {
+                SerializedProperty classProp = classesProp.GetArrayElementAtIndex(i);
+                SerializedProperty className = classProp.FindPropertyRelative("ClassName");
+                SerializedProperty statsProp = classProp.FindPropertyRelative("Stats");
+                SerializedProperty abilitiesProp = classProp.FindPropertyRelative("Abilities");
+
+                EditorGUILayout.BeginVertical("box");
+                EditorGUILayout.PropertyField(className);
+
+                EditorGUILayout.LabelField("Stats", EditorStyles.boldLabel);
+                for (int s = 0; s < statsProp.arraySize; s++)
+                {
+                    SerializedProperty statProp = statsProp.GetArrayElementAtIndex(s);
+                    SerializedProperty defProp = statProp.FindPropertyRelative("Stat");
+                    SerializedProperty valueProp = statProp.FindPropertyRelative("Value");
+
+                    EditorGUILayout.BeginHorizontal();
+                    defProp.objectReferenceValue = EditorGUILayout.ObjectField(defProp.objectReferenceValue, typeof(StatDefinition), false);
+                    valueProp.floatValue = EditorGUILayout.FloatField(valueProp.floatValue);
+                    if (GUILayout.Button("Remove", GUILayout.Width(60)))
+                    {
+                        statsProp.DeleteArrayElementAtIndex(s);
+                    }
+                    EditorGUILayout.EndHorizontal();
+                }
+
+                if (GUILayout.Button("Add Stat"))
+                {
+                    statsProp.InsertArrayElementAtIndex(statsProp.arraySize);
+                    SerializedProperty newStat = statsProp.GetArrayElementAtIndex(statsProp.arraySize - 1);
+                    newStat.FindPropertyRelative("Value").floatValue = 0f;
+                }
+
+                EditorGUILayout.PropertyField(abilitiesProp, true);
+
+                if (GUILayout.Button("Remove Class"))
+                {
+                    classesProp.DeleteArrayElementAtIndex(i);
+                    i--;
+                }
+                EditorGUILayout.EndVertical();
+            }
+
+            if (GUILayout.Button("Add Class"))
+            {
+                classesProp.InsertArrayElementAtIndex(classesProp.arraySize);
+            }
+
             so.ApplyModifiedProperties();
+            EditorGUILayout.EndScrollView();
         }
 
         private void CreateDatabase()

--- a/Assets/Scripts/Editor/StatsEditor.cs
+++ b/Assets/Scripts/Editor/StatsEditor.cs
@@ -7,6 +7,7 @@ namespace Evolution.Editor
     public class StatsEditor : EditorWindow
     {
         private StatsDatabase database;
+        private Vector2 scroll;
 
         [MenuItem("Adventure/Stats Editor")]
         public static void Open()
@@ -25,10 +26,30 @@ namespace Evolution.Editor
                 return;
             }
 
-            var so = new SerializedObject(database);
-            so.Update();
-            EditorGUILayout.PropertyField(so.FindProperty("Stats"), true);
-            so.ApplyModifiedProperties();
+            scroll = EditorGUILayout.BeginScrollView(scroll);
+
+            for (int i = 0; i < database.Stats.Count; i++)
+            {
+                EditorGUILayout.BeginHorizontal();
+                database.Stats[i] = (StatDefinition)EditorGUILayout.ObjectField(database.Stats[i], typeof(StatDefinition), false);
+                if (GUILayout.Button("Remove", GUILayout.Width(60)))
+                {
+                    database.Stats.RemoveAt(i);
+                    i--;
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (GUILayout.Button("Add Stat Reference"))
+                database.Stats.Add(null);
+
+            if (GUILayout.Button("Create New Stat"))
+                CreateStat();
+
+            EditorGUILayout.EndScrollView();
+
+            if (GUI.changed)
+                EditorUtility.SetDirty(database);
         }
 
         private void CreateDatabase()
@@ -38,6 +59,19 @@ namespace Evolution.Editor
             string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/StatsDatabase.asset");
             AssetDatabase.CreateAsset(database, path);
             AssetDatabase.SaveAssets();
+        }
+
+        private void CreateStat()
+        {
+            EnsureDataFolder();
+            if (!AssetDatabase.IsValidFolder("Assets/Data/Stats"))
+                AssetDatabase.CreateFolder("Assets/Data", "Stats");
+
+            var stat = ScriptableObject.CreateInstance<StatDefinition>();
+            string path = AssetDatabase.GenerateUniqueAssetPath("Assets/Data/Stats/NewStat.asset");
+            AssetDatabase.CreateAsset(stat, path);
+            AssetDatabase.SaveAssets();
+            database.Stats.Add(stat);
         }
 
         private void EnsureDataFolder()


### PR DESCRIPTION
## Summary
- split StatDefinition into its own ScriptableObject
- keep StatsDatabase as a list of StatDefinition assets
- allow StatsEditor to create/select Stat assets
- extend ClassEditor UI to reference StatDefinition objects

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a6cf5748832882e929dbb897b0b6