### PR TITLE
Add illusion room type and gameplay

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -21,6 +21,7 @@ namespace Evolution.Core
         [SerializeField] private SessionManager sessionManager;
         [SerializeField] private DataManager dataManager;
         [SerializeField] private ShopUI shopUI;
+        [SerializeField] private UIManager uiManager;
         [SerializeField] private string difficulty = "Easy";
 
         [Serializable]
@@ -144,6 +145,9 @@ namespace Evolution.Core
                 case RoomType.Treasure:
                     Debug.Log("Found a treasure chest!");
                     break;
+                case RoomType.Illusion:
+                    HandleIllusionRoom(room);
+                    break;
                 case RoomType.StaircaseDown:
                     currentSession.CurrentFloor++;
                     currentSession.CurrentPosition = Vector2Int.zero;
@@ -187,6 +191,46 @@ namespace Evolution.Core
                 else
                 {
                     Debug.Log("The door is locked. A key is required.");
+                }
+            }
+        }
+
+        private void HandleIllusionRoom(RoomData room)
+        {
+            if (uiManager == null || room == null)
+                return;
+
+            // Randomly choose between a crystal puzzle or perception check
+            bool crystalPuzzle = Random.value < 0.5f;
+            if (crystalPuzzle)
+            {
+                var crystals = new List<object> { "Red", "Blue", "Green" };
+                int correct = Random.Range(0, crystals.Count);
+                uiManager.ShowIllusionCrystal(correct, crystals);
+                bool solved = Random.Range(0, crystals.Count) == correct;
+                if (solved)
+                {
+                    Debug.Log("You shatter the correct crystal and the illusion fades.");
+                    uiManager.ShowRoom(room);
+                }
+                else
+                {
+                    Debug.Log("Nothing happens. The illusion remains.");
+                }
+            }
+            else
+            {
+                var options = new List<int> { 1, 2, 3 };
+                uiManager.ShowIllusionEnemyCount(options);
+                bool success = Random.value > 0.5f;
+                if (success)
+                {
+                    Debug.Log("You see through the illusion!");
+                    uiManager.ShowRoom(room);
+                }
+                else
+                {
+                    Debug.Log("The phantasms confuse you.");
                 }
             }
         }

--- a/Assets/Scripts/Dungeon/DungeonGenerator.cs
+++ b/Assets/Scripts/Dungeon/DungeonGenerator.cs
@@ -10,6 +10,7 @@ namespace Evolution.Dungeon
         Locked,
         Shop,
         Treasure,
+        Illusion,
         Boss,
         StaircaseUp,
         StaircaseDown,
@@ -48,6 +49,7 @@ namespace Evolution.Dungeon
         [SerializeField] private int lockedRoomsPerFloor = 1;
         [SerializeField] private int shopsPerFloor = 1;
         [SerializeField, Range(0f, 1f)] private float treasureChance = 0.2f;
+        [SerializeField, Range(0f, 1f)] private float illusionChance = 0.05f;
         [SerializeField] private int minLockDistance = 5;
         [SerializeField] private int minStairDistance = 6;
 
@@ -111,7 +113,9 @@ namespace Evolution.Dungeon
 
             foreach (var coord in interior)
             {
-                if (Random.value < treasureChance)
+                if (Random.value < illusionChance)
+                    roomTypes[coord] = RoomType.Illusion;
+                else if (Random.value < treasureChance)
                     roomTypes[coord] = RoomType.Treasure;
                 else
                     roomTypes.TryAdd(coord, RoomType.Monster);


### PR DESCRIPTION
## Summary
- extend `RoomType` enum with `Illusion`
- make `DungeonGenerator` optionally create illusion rooms
- allow `GameManager` to handle illusion rooms via `UIManager`
- implement simple crystal/perception puzzles for resolving illusions

## Testing
- `dotnet build -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861335ce03c8328997d059818d42bbf