### PR TITLE
Add game setup panel

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -116,12 +116,14 @@
     <Compile Include="Assets/Scripts/UI/MapUI.cs" />
     <Compile Include="Assets/Scripts/Core/GameManager.cs" />
     <Compile Include="Assets/Scripts/Core/Multiplayer/LobbyManager.cs" />
+    <Compile Include="Assets/Scripts/Core/GameType.cs" />
     <Compile Include="Assets/Scripts/Combat/BattleManager.cs" />
     <Compile Include="Assets/Scripts/Dungeon/RoomBuilder.cs" />
     <Compile Include="Assets/Scripts/UI/UIManager.cs" />
     <Compile Include="Assets/Scripts/UI/SkillsUI.cs" />
     <Compile Include="Assets/Scripts/UI/ShopUI.cs" />
     <Compile Include="Assets/Scripts/UI/MainMenuUI.cs" />
+    <Compile Include="Assets/Scripts/UI/GameSetupUI.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets/TextMesh Pro/Shaders/TMPro.cginc" />

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -24,6 +24,13 @@ namespace Evolution.Core
         [SerializeField] private UIManager uiManager;
         [SerializeField] private MapUI mapUI;
         [SerializeField] private string difficulty = "Easy";
+        [SerializeField] private GameType gameType = GameType.Solo;
+
+        /// <summary>Selected difficulty for the next session.</summary>
+        public string Difficulty { get => difficulty; set => difficulty = value; }
+
+        /// <summary>Selected game type for the next session.</summary>
+        public GameType GameType { get => gameType; set => gameType = value; }
 
         [Serializable]
         private class RoomPrefabEntry
@@ -107,6 +114,7 @@ namespace Evolution.Core
             {
                 SessionId = ownerId, // temporary id if no DB yet
                 OwnerId = ownerId,
+                Type = gameType,
                 Difficulty = difficulty,
                 CurrentFloor = 1,
                 CurrentPosition = Vector2Int.zero,

--- a/Assets/Scripts/Core/GameType.cs
+++ b/Assets/Scripts/Core/GameType.cs
@@ -1,0 +1,12 @@
+namespace Evolution.Core
+{
+    /// <summary>
+    /// Types of game sessions supported by AdventureGame.
+    /// </summary>
+    public enum GameType
+    {
+        Solo,
+        Coop,
+        PvP
+    }
+}

--- a/Assets/Scripts/Core/GameType.cs.meta
+++ b/Assets/Scripts/Core/GameType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: caef98c4586d4e2f9be144be3caeebe9

--- a/Assets/Scripts/Core/Multiplayer/LobbyManager.cs
+++ b/Assets/Scripts/Core/Multiplayer/LobbyManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Unity.Netcode;
+using Evolution.Core;
 
 namespace Evolution.Core.Multiplayer
 {
@@ -24,7 +25,7 @@ namespace Evolution.Core.Multiplayer
         /// <summary>
         /// Create a new lobby and start hosting if needed.
         /// </summary>
-        public Lobby CreateLobby(string name, int ownerId)
+        public Lobby CreateLobby(string name, int ownerId, GameType type, string difficulty)
         {
             int id = nextLobbyId++;
             var lobby = new Lobby { LobbyId = id, Name = name };
@@ -34,7 +35,8 @@ namespace Evolution.Core.Multiplayer
             {
                 SessionId = id,
                 OwnerId = ownerId,
-                Difficulty = "Normal",
+                Type = type,
+                Difficulty = difficulty,
                 CurrentFloor = 1,
                 CurrentPosition = Vector2Int.zero
             };

--- a/Assets/Scripts/Core/SessionManager.cs
+++ b/Assets/Scripts/Core/SessionManager.cs
@@ -59,6 +59,7 @@ namespace Evolution.Core
     {
         public int SessionId;
         public int OwnerId;
+        public GameType Type;
         public string Difficulty;
         public int CurrentFloor;
         public Vector2Int CurrentPosition;

--- a/Assets/Scripts/UI/GameSetupPanel.prefab
+++ b/Assets/Scripts/UI/GameSetupPanel.prefab
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: GameSetupPanel
+  m_IsActive: 0
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 11400001}
+--- !u!224 &22400000
+RectTransform:
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400001
+MonoBehaviour:
+  m_Script: {fileID: 11500000, guid: 576f4f1e09404453a69d116a1cec39bc, type: 3}
+  difficultyDropdown: {fileID: 0}
+  gameTypeDropdown: {fileID: 0}
+  confirmButton: {fileID: 0}
+  cancelButton: {fileID: 0}
+  gameManager: {fileID: 0}
+  lobbyManager: {fileID: 0}

--- a/Assets/Scripts/UI/GameSetupPanel.prefab.meta
+++ b/Assets/Scripts/UI/GameSetupPanel.prefab.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f17e6c62b15747b0aa011aea20fc0de4

--- a/Assets/Scripts/UI/GameSetupUI.cs
+++ b/Assets/Scripts/UI/GameSetupUI.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Evolution.Core;
+using Evolution.Core.Multiplayer;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Handles the new game setup panel allowing players to choose
+    /// difficulty and multiplayer mode.
+    /// </summary>
+    public class GameSetupUI : MonoBehaviour
+    {
+        [SerializeField] private Dropdown difficultyDropdown;
+        [SerializeField] private Dropdown gameTypeDropdown;
+        [SerializeField] private Button confirmButton;
+        [SerializeField] private Button cancelButton;
+        [SerializeField] private GameManager gameManager;
+        [SerializeField] private LobbyManager lobbyManager;
+
+        private void Awake()
+        {
+            if (confirmButton != null)
+                confirmButton.onClick.AddListener(OnConfirm);
+            if (cancelButton != null)
+                cancelButton.onClick.AddListener(OnCancel);
+        }
+
+        private void OnDestroy()
+        {
+            if (confirmButton != null)
+                confirmButton.onClick.RemoveListener(OnConfirm);
+            if (cancelButton != null)
+                cancelButton.onClick.RemoveListener(OnCancel);
+        }
+
+        private void OnConfirm()
+        {
+            if (gameManager == null)
+                return;
+
+            if (difficultyDropdown != null)
+            {
+                string diff = difficultyDropdown.options[difficultyDropdown.value].text;
+                gameManager.Difficulty = diff;
+            }
+
+            GameType type = GameType.Solo;
+            if (gameTypeDropdown != null)
+                type = (GameType)gameTypeDropdown.value;
+            gameManager.GameType = type;
+
+            int ownerId = 0; // local player id placeholder
+            if (type == GameType.Solo)
+            {
+                gameManager.StartNewGame(ownerId);
+            }
+            else
+            {
+                lobbyManager?.CreateLobby("Lobby" + ownerId, ownerId, type, gameManager.Difficulty);
+                gameManager.StartNewGame(ownerId);
+            }
+
+            gameObject.SetActive(false);
+        }
+
+        private void OnCancel()
+        {
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/UI/GameSetupUI.cs.meta
+++ b/Assets/Scripts/UI/GameSetupUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 576f4f1e09404453a69d116a1cec39bc

--- a/Assets/Scripts/UI/MainMenuUI.cs
+++ b/Assets/Scripts/UI/MainMenuUI.cs
@@ -13,7 +13,7 @@ namespace Evolution.UI
         [SerializeField] private Button loadGameButton;
         [SerializeField] private Button tutorialButton;
         [SerializeField] private Button highScoresButton;
-        [SerializeField] private GameObject setupPanel;
+        [SerializeField] private GameSetupUI setupPanel;
         [SerializeField] private SessionManager sessionManager;
 
         private void Awake()
@@ -43,7 +43,7 @@ namespace Evolution.UI
         private void OpenSetup()
         {
             if (setupPanel != null)
-                setupPanel.SetActive(true);
+                setupPanel.gameObject.SetActive(true);
         }
 
         private void LoadGame()


### PR DESCRIPTION
## Summary
- add `GameSetupUI` and simple `GameSetupPanel` prefab
- support a new `GameType` enum
- record game type in `SessionData` and `GameManager`
- create lobbies with difficulty and game type
- hook main menu button to open the new setup panel

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613ed2eb98832895b470b6378682b0