### PR TITLE
Add class selection panel for lobby join

### DIFF
--- a/Assets/Scripts/UI/ClassSelectUI.cs
+++ b/Assets/Scripts/UI/ClassSelectUI.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using Unity.Netcode;
+using Evolution.Core;
+using Evolution.Data;
+
+namespace Evolution.UI
+{
+    /// <summary>
+    /// Displays a dropdown of available classes and shows stats for the
+    /// selected entry. When confirmed the chosen class is assigned to the
+    /// GameManager and the player is built with that class.
+    /// </summary>
+    public class ClassSelectUI : MonoBehaviour
+    {
+        [SerializeField] private DataManager dataManager;
+        [SerializeField] private GameManager gameManager;
+        [SerializeField] private Dropdown classDropdown;
+        [SerializeField] private Image classImage;
+        [SerializeField] private Text statsText;
+        [SerializeField] private Button confirmButton;
+        [SerializeField] private List<Sprite> classSprites = new();
+
+        private List<PlayerClass> classes;
+
+        private void Awake()
+        {
+            if (confirmButton != null)
+                confirmButton.onClick.AddListener(Confirm);
+            if (classDropdown != null)
+                classDropdown.onValueChanged.AddListener(_ => UpdateDisplay());
+        }
+
+        private void OnDestroy()
+        {
+            if (confirmButton != null)
+                confirmButton.onClick.RemoveListener(Confirm);
+            if (classDropdown != null)
+                classDropdown.onValueChanged.RemoveListener(_ => UpdateDisplay());
+        }
+
+        private void OnEnable()
+        {
+            PopulateDropdown();
+            UpdateDisplay();
+        }
+
+        private void PopulateDropdown()
+        {
+            classes = dataManager != null ? dataManager.GetClassDatabase()?.Classes : null;
+            if (classDropdown == null || classes == null) return;
+
+            classDropdown.ClearOptions();
+            classDropdown.AddOptions(classes.Select(c => c.ClassName).ToList());
+        }
+
+        private void UpdateDisplay()
+        {
+            if (classes == null || classes.Count == 0 || classDropdown == null)
+                return;
+            int index = Mathf.Clamp(classDropdown.value, 0, classes.Count - 1);
+            var cls = classes[index];
+
+            if (classImage != null && index < classSprites.Count)
+                classImage.sprite = classSprites[index];
+
+            if (statsText != null)
+            {
+                var lines = cls.Stats
+                    .Where(s => s != null && s.Stat != null)
+                    .Select(s => $"{s.Stat.Name}: {s.Value}");
+                statsText.text = string.Join("\n", lines);
+            }
+        }
+
+        private void Confirm()
+        {
+            if (classes == null || classDropdown == null || gameManager == null)
+                return;
+            int index = Mathf.Clamp(classDropdown.value, 0, classes.Count - 1);
+            var cls = classes[index];
+            gameManager.SelectedClass = cls;
+
+            int owner = NetworkManager.Singleton != null ? (int)NetworkManager.Singleton.LocalClientId : 0;
+            gameManager.BuildPlayer(owner, cls);
+
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/UI/LobbyUI.cs
+++ b/Assets/Scripts/UI/LobbyUI.cs
@@ -23,6 +23,7 @@ namespace Evolution.UI
         [SerializeField] private Button createButton;
         [SerializeField] private Button startButton;
         [SerializeField] private string gameplayScene = "SampleScene";
+        [SerializeField] private ClassSelectUI classSelectPanel;
 
         private Lobby currentLobby;
 
@@ -87,6 +88,8 @@ namespace Evolution.UI
             currentLobby = lobbyManager.CreateLobby(name, (int)NetworkManager.Singleton.LocalClientId, GameType.Multiplayer, "Easy");
             // passwordInput is not used by LobbyManager yet, but saved for future use
             Refresh();
+            if (classSelectPanel != null)
+                classSelectPanel.gameObject.SetActive(true);
         }
 
         private void JoinLobby(int lobbyId)
@@ -96,6 +99,8 @@ namespace Evolution.UI
             if (lobbyManager.JoinLobby(lobbyId, NetworkManager.Singleton.LocalClientId))
             {
                 currentLobby = lobbyManager.ListLobbies().FirstOrDefault(l => l.LobbyId == lobbyId);
+                if (classSelectPanel != null)
+                    classSelectPanel.gameObject.SetActive(true);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ buttons. A create lobby form allows specifying a name and optional password.
 Hosts can start the game at any time (up to eight players) which will load the
 configured gameplay scene for all members while keeping the lobby joinable.
 
+Joining a lobby now displays a class selection panel. Players choose from the
+classes defined in `ClassDatabase`, review their stats and confirm before
+spawning. The chosen class is applied through `GameManager.BuildPlayer` when the
+game starts.
+


### PR DESCRIPTION
## Summary
- implement `ClassSelectUI` for picking a player class
- allow `GameManager` to build players using a specified class
- show the class select panel whenever a lobby is created or joined
- document the new flow in `README.md`

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686143822b808328b55324778faf5d98