### PR TITLE
Switch UI text to TMP

### DIFF
--- a/Assets/Scripts/UI/ClassSelectUI.cs
+++ b/Assets/Scripts/UI/ClassSelectUI.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using Unity.Netcode;
 using Evolution.Core;
 using Evolution.Data;
@@ -19,7 +20,7 @@ namespace Evolution.UI
         [SerializeField] private GameManager gameManager;
         [SerializeField] private Dropdown classDropdown;
         [SerializeField] private Image classImage;
-        [SerializeField] private Text statsText;
+        [SerializeField] private TMP_Text statsText;
         [SerializeField] private Button confirmButton;
         [SerializeField] private List<Sprite> classSprites = new();
 

--- a/Assets/Scripts/UI/LobbyUI.cs
+++ b/Assets/Scripts/UI/LobbyUI.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using UnityEngine.SceneManagement;
 using Unity.Netcode;
 using Evolution.Core.Multiplayer;
@@ -67,7 +68,7 @@ namespace Evolution.UI
             foreach (var lobby in lobbies)
             {
                 var item = Instantiate(lobbyItemPrefab, lobbyListRoot);
-                var text = item.GetComponentInChildren<Text>();
+                var text = item.GetComponentInChildren<TMP_Text>();
                 if (text != null)
                     text.text = $"{lobby.Name} ({lobby.Players.Count}/8)";
                 var btn = item.GetComponentInChildren<Button>();

--- a/Assets/Scripts/UI/ShopUI.cs
+++ b/Assets/Scripts/UI/ShopUI.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using Evolution.Core;
 using Evolution.Data;
 
@@ -41,7 +42,7 @@ namespace Evolution.UI
             foreach (var item in shop.Items.Where(i => i != null))
             {
                 var btn = Instantiate(itemButtonPrefab, buttonRoot);
-                var text = btn.GetComponentInChildren<Text>();
+                var text = btn.GetComponentInChildren<TMP_Text>();
                 if (text != null)
                     text.text = item.Name;
                 var data = item; // local capture

--- a/Assets/Scripts/UI/SkillsUI.cs
+++ b/Assets/Scripts/UI/SkillsUI.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using Evolution.Combat;
 
 namespace Evolution.UI
@@ -65,7 +66,7 @@ namespace Evolution.UI
             foreach (var ab in abilities)
             {
                 var btn = Instantiate(skillButtonPrefab, buttonRoot);
-                var text = btn.GetComponentInChildren<Text>();
+                var text = btn.GetComponentInChildren<TMP_Text>();
                 if (text != null)
                     text.text = ab.Name;
                 var ability = ab; // capture local
@@ -111,7 +112,7 @@ namespace Evolution.UI
                 var ab = player.Abilities[i];
                 var btn = spawned[i];
                 if (btn == null) continue;
-                var text = btn.GetComponentInChildren<Text>();
+                var text = btn.GetComponentInChildren<TMP_Text>();
                 float cd = player.Cooldowns.TryGetValue(ab.Name, out var c) ? c : 0f;
                 if (text != null)
                     text.text = cd > 0 ? $"{ab.Name} ({cd:0})" : ab.Name;

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
+using TMPro;
 using Evolution.Dungeon;
 
 namespace Evolution.UI
@@ -18,10 +18,10 @@ namespace Evolution.UI
         [SerializeField] private CanvasGroup menuCanvas;
 
         [Header("Room Elements")]
-        [SerializeField] private Text roomDescription;
+        [SerializeField] private TMP_Text roomDescription;
 
         [Header("Battle Elements")]
-        [SerializeField] private Text battleLog;
+        [SerializeField] private TMP_Text battleLog;
 
         [Header("Theme")]
         [SerializeField] private Color themeColor = Color.white;


### PR DESCRIPTION
## Summary
- swap Unity `Text` references for `TMP_Text`
- update skill, shop, lobby and class UI scripts
- adjust UIManager to use TMP components

No scenes contained `Text` components so no asset edits were needed.

## Testing
- `dotnet build "AdventureGame 1.0.sln" -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614ad28f6c83289a4966998917c872