### PR TITLE
Change UI font asset type

### DIFF
--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -25,10 +25,10 @@ namespace Evolution.UI
 
         [Header("Theme")]
         [SerializeField] private Color themeColor = Color.white;
-        [SerializeField] private Font themeFont;
+        [SerializeField] private TMP_FontAsset themeFont;
 
         public Color ThemeColor { get => themeColor; set { themeColor = value; ApplyTheme(); } }
-        public Font ThemeFont { get => themeFont; set { themeFont = value; ApplyTheme(); } }
+        public TMP_FontAsset ThemeFont { get => themeFont; set { themeFont = value; ApplyTheme(); } }
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- use `TMP_FontAsset` for `themeFont` in `UIManager`
- ensure inspector and theme application use TMP font asset

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686279c542208328ab90f3a8de3cfa31