### PR TITLE
Use FindFirstObjectByType for dungeon generator

### DIFF
--- a/Assets/Scripts/Core/Multiplayer/PlayerController.cs
+++ b/Assets/Scripts/Core/Multiplayer/PlayerController.cs
@@ -30,7 +30,7 @@ namespace Evolution.Core.Multiplayer
         private void Start()
         {
             if (dungeonGenerator == null)
-                dungeonGenerator = FindObjectOfType<DungeonGenerator>();
+                dungeonGenerator = FindFirstObjectByType<DungeonGenerator>();
         }
 
         public override void OnNetworkSpawn()


### PR DESCRIPTION
## Summary
- update PlayerController to locate the DungeonGenerator using `FindFirstObjectByType`

## Testing
- `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68627a33e5e883288c60a2bd63827563