### PR TITLE
Alias UnityEngine.Random

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Random = UnityEngine.Random;
 using Evolution.Dungeon;
 using Evolution.Combat;
 using Evolution.Data;


### PR DESCRIPTION
## Summary
- alias UnityEngine.Random in GameManager

## Testing
- `dotnet build AdventureGame 1.0.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627aa96428832884d9e845330f2bf2