### PR TITLE
Fix lobby type

### DIFF
--- a/Assets/Scripts/UI/LobbyUI.cs
+++ b/Assets/Scripts/UI/LobbyUI.cs
@@ -5,6 +5,7 @@ using TMPro;
 using UnityEngine.SceneManagement;
 using Unity.Netcode;
 using Evolution.Core.Multiplayer;
+using Evolution.Core;
 
 namespace Evolution.UI
 {
@@ -87,7 +88,7 @@ namespace Evolution.UI
 
             string name = lobbyNameInput != null ? lobbyNameInput.text : $"Lobby{Random.Range(1000,9999)}";
             string pwd = passwordInput != null ? passwordInput.text : null;
-            currentLobby = lobbyManager.CreateLobby(name, (int)NetworkManager.Singleton.LocalClientId, GameType.Multiplayer, "Easy", pwd);
+            currentLobby = lobbyManager.CreateLobby(name, (int)NetworkManager.Singleton.LocalClientId, GameType.Coop, "Easy", pwd);
             Refresh();
             if (classSelectPanel != null)
                 classSelectPanel.gameObject.SetActive(true);


### PR DESCRIPTION
## Summary
- add missing Evolution.Core namespace in LobbyUI
- use Coop lobby type

## Testing
- `dotnet build "AdventureGame 1.0.sln"` *(fails: Unity dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68627ad1f0d88328a77b58383b637582