### PR TITLE
Clean prefab component lists

### DIFF
--- a/Assets/Prefabs/Door.prefab
+++ b/Assets/Prefabs/Door.prefab
@@ -5,10 +5,10 @@ GameObject:
   m_Name: Door
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # BoxCollider
-  - component: {fileID: 6} # Door
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
+  - component: {fileID: 6}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Boss.prefab
+++ b/Assets/Prefabs/Rooms/Boss.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: BossRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Exit.prefab
+++ b/Assets/Prefabs/Rooms/Exit.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: ExitRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Locked.prefab
+++ b/Assets/Prefabs/Rooms/Locked.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: LockedRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Monster.prefab
+++ b/Assets/Prefabs/Rooms/Monster.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: MonsterRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Safe.prefab
+++ b/Assets/Prefabs/Rooms/Safe.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: SafeRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Shop.prefab
+++ b/Assets/Prefabs/Rooms/Shop.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: ShopRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/StaircaseDown.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseDown.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: StaircaseDownRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/StaircaseUp.prefab
+++ b/Assets/Prefabs/Rooms/StaircaseUp.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: StaircaseUpRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Rooms/Treasure.prefab
+++ b/Assets/Prefabs/Rooms/Treasure.prefab
@@ -5,9 +5,9 @@ GameObject:
   m_Name: TreasureRoom
   m_Component:
   - component: {fileID: 2}
-  - component: {fileID: 3} # MeshFilter
-  - component: {fileID: 4} # MeshRenderer
-  - component: {fileID: 5} # RoomPrefab
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  - component: {fileID: 5}
 --- !u!4 &2
 Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
## Summary
- strip inline comments from all prefab component entries

Prefab component definitions no longer contain YAML comments, which previously caused warnings on import.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68627b733ce48328945b35d871f6f255