### PR TITLE
Add postprocessor to recalc normals for tile models

### DIFF
--- a/Assets/Scripts/Editor/ModelImportPostprocessor.cs
+++ b/Assets/Scripts/Editor/ModelImportPostprocessor.cs
@@ -1,0 +1,16 @@
+using UnityEditor;
+
+namespace Evolution.Editor
+{
+    public class ModelImportPostprocessor : AssetPostprocessor
+    {
+        private void OnPreprocessModel()
+        {
+            ModelImporter importer = (ModelImporter)assetImporter;
+            if (assetPath.StartsWith("Assets/Models/Tiles"))
+            {
+                importer.importNormals = ModelImporterNormals.Calculate;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ModelImportPostprocessor` to force Unity to recalculate normals when importing tile models

## Testing
- `echo 'No tests present'`

------
https://chatgpt.com/codex/tasks/task_e_68627bb9afa083288d53ef987e91d8ba